### PR TITLE
Removed Valencian

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -462,12 +462,6 @@
     "name": "Catalan"
   },
   {
-    "alpha2": "ca",
-    "alpha3": "cat",
-    "bibliographic": "",
-    "name": "Valencian"
-  },
-  {
     "alpha2": "",
     "alpha3": "cau",
     "bibliographic": "",


### PR DESCRIPTION
Removed Valencian as it is a dialect spoken in Valencia, part of catalan countries. Valencian is the name of catalan in Valencia. The main important reason of deleting valencian is a conflict with "Catalan" as its apha3 name is the same